### PR TITLE
Fix getCMDBDataUpdate function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
 
     agent {
-        node { label 'jenkinsworker00' }
+        node { label 'jenkinsworker01' }
     }
 
     environment {

--- a/src/main/java/it/reply/orchestrator/service/AbstractCmdbServiceImpl.java
+++ b/src/main/java/it/reply/orchestrator/service/AbstractCmdbServiceImpl.java
@@ -17,6 +17,8 @@
 
 package it.reply.orchestrator.service;
 
+import it.reply.orchestrator.dal.entity.Deployment;
+import it.reply.orchestrator.dto.CloudProviderEndpoint;
 import it.reply.orchestrator.dto.RankCloudProvidersMessage;
 import it.reply.orchestrator.dto.cmdb.CloudProvider;
 import it.reply.orchestrator.dto.cmdb.CloudService;
@@ -32,6 +34,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.Sets;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -85,4 +90,12 @@ public abstract class AbstractCmdbServiceImpl implements CmdbService {
     provider.setServices(services);
     return provider;
   }
+
+  @Override
+  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation, RankCloudProvidersMessage rankCloudProvidersMessage) {
+    String cloudProviderId = deployment.getCloudProviderName();
+    CloudProviderEndpoint cloudProviderEndpoint = deployment.getCloudProviderEndpoint();
+    Set<String> servicesWithSla = Sets.newHashSet(cloudProviderEndpoint.getCpComputeServiceId());
+    return fillCloudProviderInfo(cloudProviderId, servicesWithSla, organisation, rankCloudProvidersMessage);
+  };
 }

--- a/src/main/java/it/reply/orchestrator/service/AbstractCmdbServiceImpl.java
+++ b/src/main/java/it/reply/orchestrator/service/AbstractCmdbServiceImpl.java
@@ -97,5 +97,5 @@ public abstract class AbstractCmdbServiceImpl implements CmdbService {
     Set<String> servicesWithSla = Sets.newHashSet(cloudProviderEndpoint.getCpComputeServiceId());
     return fillCloudProviderInfo(cloudProviderId, servicesWithSla, organisation,
         rankCloudProvidersMessage);
-  };
+  }
 }

--- a/src/main/java/it/reply/orchestrator/service/AbstractCmdbServiceImpl.java
+++ b/src/main/java/it/reply/orchestrator/service/AbstractCmdbServiceImpl.java
@@ -17,6 +17,7 @@
 
 package it.reply.orchestrator.service;
 
+import com.google.common.collect.Sets;
 import it.reply.orchestrator.dal.entity.Deployment;
 import it.reply.orchestrator.dto.CloudProviderEndpoint;
 import it.reply.orchestrator.dto.RankCloudProvidersMessage;
@@ -34,9 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.Sets;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -92,10 +90,12 @@ public abstract class AbstractCmdbServiceImpl implements CmdbService {
   }
 
   @Override
-  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation, RankCloudProvidersMessage rankCloudProvidersMessage) {
+  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation,
+      RankCloudProvidersMessage rankCloudProvidersMessage) {
     String cloudProviderId = deployment.getCloudProviderName();
     CloudProviderEndpoint cloudProviderEndpoint = deployment.getCloudProviderEndpoint();
     Set<String> servicesWithSla = Sets.newHashSet(cloudProviderEndpoint.getCpComputeServiceId());
-    return fillCloudProviderInfo(cloudProviderId, servicesWithSla, organisation, rankCloudProvidersMessage);
+    return fillCloudProviderInfo(cloudProviderId, servicesWithSla, organisation,
+        rankCloudProvidersMessage);
   };
 }

--- a/src/main/java/it/reply/orchestrator/service/CmdbService.java
+++ b/src/main/java/it/reply/orchestrator/service/CmdbService.java
@@ -51,7 +51,8 @@ public interface CmdbService {
 
   public CloudProvider fillCloudProviderInfo(String providerId, Set<String> servicesWithSla,
       String organisation, RankCloudProvidersMessage rankCloudProvidersMessage);
-  
-  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation, RankCloudProvidersMessage rankCloudProvidersMessage);
+
+  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation,
+      RankCloudProvidersMessage rankCloudProvidersMessage);
 
 }

--- a/src/main/java/it/reply/orchestrator/service/CmdbService.java
+++ b/src/main/java/it/reply/orchestrator/service/CmdbService.java
@@ -17,6 +17,7 @@
 
 package it.reply.orchestrator.service;
 
+import it.reply.orchestrator.dal.entity.Deployment;
 import it.reply.orchestrator.dto.RankCloudProvidersMessage;
 import it.reply.orchestrator.dto.cmdb.CloudProvider;
 import it.reply.orchestrator.dto.cmdb.CloudService;
@@ -50,5 +51,7 @@ public interface CmdbService {
 
   public CloudProvider fillCloudProviderInfo(String providerId, Set<String> servicesWithSla,
       String organisation, RankCloudProvidersMessage rankCloudProvidersMessage);
+  
+  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation, RankCloudProvidersMessage rankCloudProvidersMessage);
 
 }

--- a/src/main/java/it/reply/orchestrator/service/CmdbServiceV2Impl.java
+++ b/src/main/java/it/reply/orchestrator/service/CmdbServiceV2Impl.java
@@ -40,7 +40,6 @@ import it.reply.orchestrator.dto.fedreg.Network;
 import it.reply.orchestrator.dto.fedreg.Project;
 import it.reply.orchestrator.dto.fedreg.Quota;
 import it.reply.orchestrator.dto.fedreg.Region;
-import it.reply.orchestrator.dto.slam.SlamPreferences;
 import it.reply.orchestrator.exception.service.DeploymentException;
 import it.reply.orchestrator.service.security.OAuth2TokenService;
 import java.net.MalformedURLException;
@@ -475,17 +474,18 @@ public class CmdbServiceV2Impl implements CmdbService {
   }
 
   @Override
-  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation, RankCloudProvidersMessage rankCloudProvidersMessage) {
+  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation,
+      RankCloudProvidersMessage rankCloudProvidersMessage) {
     OidcTokenId requestedWithToken = rankCloudProvidersMessage.getRequestedWithToken();
     Optional<String> regionName = deployment.getCloudProviderEndpoint().getRegion();
     String identityServiceEndpoint = deployment.getCloudProviderEndpoint().getCpEndpoint();
 
     URI requestUriFedRegProject = UriComponentsBuilder
-    .fromHttpUrl(cmdbProperties.getUrl() + cmdbProperties.getTenantsListPath())
-    .queryParam("with_conn", true)
-    .queryParam("region_name", regionName)
-    .queryParam("identity_service_endpoint", identityServiceEndpoint).build().normalize().toUri();
-    
+        .fromHttpUrl(cmdbProperties.getUrl() + cmdbProperties.getTenantsListPath())
+        .queryParam("with_conn", true).queryParam("region_name", regionName)
+        .queryParam("identity_service_endpoint", identityServiceEndpoint).build().normalize()
+        .toUri();
+
     List<Project> projectCall =
         oauth2TokenService.executeWithClientForResult(requestedWithToken, accessToken -> {
           HeadersBuilder<?> requestBuilder = RequestEntity.get(requestUriFedRegProject);

--- a/src/main/java/it/reply/orchestrator/service/CmdbServiceV2Impl.java
+++ b/src/main/java/it/reply/orchestrator/service/CmdbServiceV2Impl.java
@@ -452,12 +452,12 @@ public class CmdbServiceV2Impl implements CmdbService {
   public CloudProvider fillCloudProviderInfo(String providerId, Set<String> servicesWithSla,
       String organisation, RankCloudProvidersMessage rankCloudProvidersMessage) {
     OidcTokenId requestedWithToken = rankCloudProvidersMessage.getRequestedWithToken();
-    String userGroup = rankCloudProvidersMessage.getSlamPreferences().getPreferences().get(0).getCustomer();
+    String userGroup =
+        rankCloudProvidersMessage.getSlamPreferences().getPreferences().get(0).getCustomer();
 
     URI requestUriFedRegProject = UriComponentsBuilder
         .fromHttpUrl(cmdbProperties.getUrl() + cmdbProperties.getTenantsListPath())
-        .queryParam("with_conn", true)
-        .queryParam("user_group_uid", userGroup)
+        .queryParam("with_conn", true).queryParam("user_group_uid", userGroup)
         .queryParam("provider_uid", providerId).build().normalize().toUri();
 
     List<Project> projectCall =
@@ -497,6 +497,5 @@ public class CmdbServiceV2Impl implements CmdbService {
         }, OAuth2TokenService.restTemplateTokenRefreshEvaluator).getBody();
 
     return remapAttributes(projectCall.get(0));
-  };
-
+  }
 }

--- a/src/main/java/it/reply/orchestrator/service/CmdbServiceV2Impl.java
+++ b/src/main/java/it/reply/orchestrator/service/CmdbServiceV2Impl.java
@@ -482,7 +482,7 @@ public class CmdbServiceV2Impl implements CmdbService {
 
     URI requestUriFedRegProject = UriComponentsBuilder
         .fromHttpUrl(cmdbProperties.getUrl() + cmdbProperties.getTenantsListPath())
-        .queryParam("with_conn", true).queryParam("region_name", regionName)
+        .queryParam("with_conn", true).queryParam("region_name", regionName.orElseGet(() -> null))
         .queryParam("identity_service_endpoint", identityServiceEndpoint).build().normalize()
         .toUri();
 

--- a/src/main/java/it/reply/orchestrator/service/CmdbServiceV2Impl.java
+++ b/src/main/java/it/reply/orchestrator/service/CmdbServiceV2Impl.java
@@ -19,6 +19,7 @@ package it.reply.orchestrator.service;
 
 import it.reply.orchestrator.annotation.ServiceVersion;
 import it.reply.orchestrator.config.properties.CmdbProperties;
+import it.reply.orchestrator.dal.entity.Deployment;
 import it.reply.orchestrator.dal.entity.OidcTokenId;
 import it.reply.orchestrator.dto.RankCloudProvidersMessage;
 import it.reply.orchestrator.dto.cmdb.CloudProvider;
@@ -39,6 +40,7 @@ import it.reply.orchestrator.dto.fedreg.Network;
 import it.reply.orchestrator.dto.fedreg.Project;
 import it.reply.orchestrator.dto.fedreg.Quota;
 import it.reply.orchestrator.dto.fedreg.Region;
+import it.reply.orchestrator.dto.slam.SlamPreferences;
 import it.reply.orchestrator.exception.service.DeploymentException;
 import it.reply.orchestrator.service.security.OAuth2TokenService;
 import java.net.MalformedURLException;
@@ -48,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -449,14 +452,13 @@ public class CmdbServiceV2Impl implements CmdbService {
   @Override
   public CloudProvider fillCloudProviderInfo(String providerId, Set<String> servicesWithSla,
       String organisation, RankCloudProvidersMessage rankCloudProvidersMessage) {
-
     OidcTokenId requestedWithToken = rankCloudProvidersMessage.getRequestedWithToken();
+    String userGroup = rankCloudProvidersMessage.getSlamPreferences().getPreferences().get(0).getCustomer();
 
     URI requestUriFedRegProject = UriComponentsBuilder
         .fromHttpUrl(cmdbProperties.getUrl() + cmdbProperties.getTenantsListPath())
         .queryParam("with_conn", true)
-        .queryParam("user_group_uid",
-            rankCloudProvidersMessage.getSlamPreferences().getPreferences().get(0).getCustomer())
+        .queryParam("user_group_uid", userGroup)
         .queryParam("provider_uid", providerId).build().normalize().toUri();
 
     List<Project> projectCall =
@@ -471,5 +473,30 @@ public class CmdbServiceV2Impl implements CmdbService {
 
     return remapAttributes(projectCall.get(0));
   }
+
+  @Override
+  public CloudProvider getUpdatedCloudProviderInfo(Deployment deployment, String organisation, RankCloudProvidersMessage rankCloudProvidersMessage) {
+    OidcTokenId requestedWithToken = rankCloudProvidersMessage.getRequestedWithToken();
+    Optional<String> regionName = deployment.getCloudProviderEndpoint().getRegion();
+    String identityServiceEndpoint = deployment.getCloudProviderEndpoint().getCpEndpoint();
+
+    URI requestUriFedRegProject = UriComponentsBuilder
+    .fromHttpUrl(cmdbProperties.getUrl() + cmdbProperties.getTenantsListPath())
+    .queryParam("with_conn", true)
+    .queryParam("region_name", regionName)
+    .queryParam("identity_service_endpoint", identityServiceEndpoint).build().normalize().toUri();
+    
+    List<Project> projectCall =
+        oauth2TokenService.executeWithClientForResult(requestedWithToken, accessToken -> {
+          HeadersBuilder<?> requestBuilder = RequestEntity.get(requestUriFedRegProject);
+          if (accessToken != null) {
+            requestBuilder.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+          }
+          return restTemplate.exchange(requestBuilder.build(),
+              new ParameterizedTypeReference<List<Project>>() {});
+        }, OAuth2TokenService.restTemplateTokenRefreshEvaluator).getBody();
+
+    return remapAttributes(projectCall.get(0));
+  };
 
 }

--- a/src/main/java/it/reply/orchestrator/service/commands/GetCmdbDataUpdate.java
+++ b/src/main/java/it/reply/orchestrator/service/commands/GetCmdbDataUpdate.java
@@ -17,23 +17,17 @@
 
 package it.reply.orchestrator.service.commands;
 
-import com.google.common.collect.Sets;
 import it.reply.orchestrator.dal.entity.Deployment;
-import it.reply.orchestrator.dal.entity.OidcEntity;
 import it.reply.orchestrator.dal.entity.OidcTokenId;
-import it.reply.orchestrator.dal.repository.OidcEntityRepository;
-import it.reply.orchestrator.dto.CloudProviderEndpoint;
 import it.reply.orchestrator.dto.RankCloudProvidersMessage;
 import it.reply.orchestrator.dto.cmdb.CloudProvider;
 import it.reply.orchestrator.dto.deployment.DeploymentMessage;
 import it.reply.orchestrator.dto.workflow.CloudServiceWf;
 import it.reply.orchestrator.dto.workflow.CloudServicesOrderedIterator;
-import it.reply.orchestrator.exception.service.DeploymentException;
 import it.reply.orchestrator.service.CmdbService;
 import it.reply.orchestrator.service.security.OAuth2TokenService;
 import it.reply.orchestrator.utils.WorkflowConstants;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,15 +49,16 @@ public class GetCmdbDataUpdate extends BaseDeployCommand {
 
     OidcTokenId requestedWithToken = deploymentMessage.getRequestedWithToken();
     String organisation = Optional.ofNullable(deployment.getUserGroup())
-      .orElse(oauth2TokenService.getOrganization(requestedWithToken));
+        .orElse(oauth2TokenService.getOrganization(requestedWithToken));
     RankCloudProvidersMessage rankCloudProvidersMessage = new RankCloudProvidersMessage();
-    rankCloudProvidersMessage.setRequestedWithToken(requestedWithToken);    
-    
-    CloudProvider cloudProvider = cmdbService.getUpdatedCloudProviderInfo(deployment, organisation, rankCloudProvidersMessage);
+    rankCloudProvidersMessage.setRequestedWithToken(requestedWithToken);
+
+    CloudProvider cloudProvider = cmdbService.getUpdatedCloudProviderInfo(deployment, organisation,
+        rankCloudProvidersMessage);
 
     CloudServicesOrderedIterator cloudServicesOrderedIterator =
-        new CloudServicesOrderedIterator(cloudProvider.getServices().values().stream().map(
-            CloudServiceWf::new).collect(Collectors.toList()));
+        new CloudServicesOrderedIterator(cloudProvider.getServices().values().stream()
+            .map(CloudServiceWf::new).collect(Collectors.toList()));
     cloudServicesOrderedIterator.next();
     deploymentMessage.setCloudServicesOrderedIterator(cloudServicesOrderedIterator);
   }

--- a/src/main/java/it/reply/orchestrator/service/commands/GetCmdbDataUpdate.java
+++ b/src/main/java/it/reply/orchestrator/service/commands/GetCmdbDataUpdate.java
@@ -19,13 +19,16 @@ package it.reply.orchestrator.service.commands;
 
 import com.google.common.collect.Sets;
 import it.reply.orchestrator.dal.entity.Deployment;
+import it.reply.orchestrator.dal.entity.OidcEntity;
 import it.reply.orchestrator.dal.entity.OidcTokenId;
+import it.reply.orchestrator.dal.repository.OidcEntityRepository;
 import it.reply.orchestrator.dto.CloudProviderEndpoint;
 import it.reply.orchestrator.dto.RankCloudProvidersMessage;
 import it.reply.orchestrator.dto.cmdb.CloudProvider;
 import it.reply.orchestrator.dto.deployment.DeploymentMessage;
 import it.reply.orchestrator.dto.workflow.CloudServiceWf;
 import it.reply.orchestrator.dto.workflow.CloudServicesOrderedIterator;
+import it.reply.orchestrator.exception.service.DeploymentException;
 import it.reply.orchestrator.service.CmdbService;
 import it.reply.orchestrator.service.security.OAuth2TokenService;
 import it.reply.orchestrator.utils.WorkflowConstants;
@@ -47,24 +50,22 @@ public class GetCmdbDataUpdate extends BaseDeployCommand {
 
   @Override
   public void execute(DelegateExecution execution, DeploymentMessage deploymentMessage) {
-    OidcTokenId requestedWithToken = deploymentMessage.getRequestedWithToken();
     Deployment deployment = getDeployment(deploymentMessage);
-    CloudProviderEndpoint cloudProviderEndpoint = deployment.getCloudProviderEndpoint();
-    String cloudProviderId = deployment.getCloudProviderName();
-    Set<String> serviceWithSla = Sets.newHashSet(cloudProviderEndpoint.getCpComputeServiceId());
-    //String organisation = oauth2TokenService.getOrganization(
-    //    deploymentMessage.getRequestedWithToken());
+    deploymentMessage.setChosenCloudProviderEndpoint(deployment.getCloudProviderEndpoint());
+
+    OidcTokenId requestedWithToken = deploymentMessage.getRequestedWithToken();
     String organisation = Optional.ofNullable(deployment.getUserGroup())
-           .orElse(oauth2TokenService.getOrganization(deploymentMessage.getRequestedWithToken()));
-    CloudProvider cloudProvider = cmdbService.fillCloudProviderInfo(cloudProviderId, serviceWithSla,
-        organisation, new RankCloudProvidersMessage());
+      .orElse(oauth2TokenService.getOrganization(requestedWithToken));
+    RankCloudProvidersMessage rankCloudProvidersMessage = new RankCloudProvidersMessage();
+    rankCloudProvidersMessage.setRequestedWithToken(requestedWithToken);    
+    
+    CloudProvider cloudProvider = cmdbService.getUpdatedCloudProviderInfo(deployment, organisation, rankCloudProvidersMessage);
 
     CloudServicesOrderedIterator cloudServicesOrderedIterator =
         new CloudServicesOrderedIterator(cloudProvider.getServices().values().stream().map(
             CloudServiceWf::new).collect(Collectors.toList()));
     cloudServicesOrderedIterator.next();
     deploymentMessage.setCloudServicesOrderedIterator(cloudServicesOrderedIterator);
-    deploymentMessage.setChosenCloudProviderEndpoint(cloudProviderEndpoint);
   }
 
   @Override


### PR DESCRIPTION
With the changes introduced to use the fed-reg, the fillCloudProviderInfo function does not work when updating a deployment. This PR resolves this problem introducing a new function.